### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module prencrypt
+module github.com/hongyuefan/prencrypt
 
 go 1.14
 


### PR DESCRIPTION
In order to run `go get github.com/hongyuefan/prencrypt`, prefix should be added.